### PR TITLE
Cache Rails.application.routes.url_helpers

### DIFF
--- a/lib/admin_script/base.rb
+++ b/lib/admin_script/base.rb
@@ -55,6 +55,10 @@ module AdminScript
       def script
         instance_method(:perform).source
       end
+
+      def url_helpers
+        @@url_helpers ||= Rails.application.routes.url_helpers
+      end
     end
 
     def initialize(*)
@@ -78,7 +82,8 @@ module AdminScript
     private
 
     def url_helpers
-      Rails.application.routes.url_helpers
+      # FIXME: how to cache url_helpers?
+      self.class.url_helpers
     end
   end
 end


### PR DESCRIPTION
Rails.application.routes.url_helpers is very slow because it returns new module.