### PR TITLE
Replace method name from `type_attribute` to `attribute` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ end
 
 class AdminScript::AwesomeScript < AdminScript::Base
   attribute :id, :integer
-  type_attribute :body, :string
+  attribute :body, :string
 end
 ```
 


### PR DESCRIPTION
Update README.

`type_attribute` method is removed in v1.0.0, but it remained in sample code.