### PR TITLE
Reload models after clearing dependencies in development

### DIFF
--- a/lib/admin_script/engine.rb
+++ b/lib/admin_script/engine.rb
@@ -3,26 +3,14 @@ module AdminScript
     isolate_namespace AdminScript
 
     initializer 'admin_script.load_subclasses', before: :set_clear_dependencies_hook do |app|
-      path = app.paths['app/models'].first
+      config.to_prepare do
+        # Reload app/models/admin_script/**/*.rb
+        path = app.paths['app/models'].first
 
-      reload_scrpits = -> {
         Dir["#{path}/admin_script/**/*.rb"].each do |full_path|
           require_dependency(full_path)
         end
-      }
-
-      reloader = AdminScript::Reloader.file_watcher.new([], { "#{path}/admin_script" => [:rb] }) do
-        reload_scrpits.call
       end
-
-      config.to_prepare do
-        reloader.execute_if_updated
-      end
-
-      # Execute reloader at the first
-      reload_scrpits.call
-
-      app.reloaders << reloader
     end
 
     config.after_initialize do


### PR DESCRIPTION
`AdminScript::Reloader.file_watcher` doesn't reload `admin_script/**/*.rb` after changing file in `app/`.
Instead of, reload all `admin_script/**/*` every request in development mode.